### PR TITLE
Fix broken master

### DIFF
--- a/app.py
+++ b/app.py
@@ -177,7 +177,7 @@ def list_data_objects(**kwargs):
     per_page = 10
     page_token = "0"
     if req_body and (req_body.get('page_size', None)):
-        per_page = req_body.get('page_size')
+        per_page = int(req_body.get('page_size'))
     if req_body and (req_body.get('page_token', None)):
         page_token = req_body.get('page_token')
     query = {'size': per_page + 1}

--- a/app.py
+++ b/app.py
@@ -186,7 +186,7 @@ def list_data_objects(**kwargs):
     if req_body and req_body.get('alias', None):
         # We kludge on our own tag scheme
         alias = req_body.get('alias')
-        k = alias.split(":")[0]
+        k = '{}.keyword'.format(alias.split(':')[0])
         v = ":".join(alias.split(":")[1:])
         query['query'] = {'match': {k: v}}
     resp = client.make_request(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,9 @@
 import json
 import logging
+import time
 from unittest import TestCase
 import urllib
+import uuid
 
 from chalice.config import Config
 from chalice.local import LocalGateway
@@ -112,111 +114,103 @@ class TestApp(TestCase):
         r = self.make_request('GET', '/ga4gh/dos/v1/dataobjects?page_size=1&page_token=1')
         self.assertEqual(len(r['data_objects']), 1)
 
-    def test_update(self):
+    def test_update_unauthenticated(self):
+        """
+        Demonstrates how attempts to update a data object while not
+        properly authenticated will be refused.
+        """
+        # List all the data objects and pick a "random" one to test.
+        r = self.make_request('GET', '/ga4gh/dos/v1/dataobjects')
+        data_obj = r['data_objects'][1]
+
+        # Try and update it without specifying an auth token.auth
+        r = self.make_request('PUT',
+                              '/ga4gh/dos/v1/dataobjects/' + data_obj['id'],
+                              headers={'content-type': 'application/json'},
+                              body={'data_object': data_obj},
+                              expected_status=403)
+
+    def _test_alias(self, alias, expect_fail=False):
+        """
+        Helper test that demonstrates updating a data object with
+        a given alias.
+
+        :param bool expect_fail: expect that updating the alias will fail, and
+                                 stop once it does. This exists only for
+                                :meth:`test_update_protected_key`
+        """
+        # First, select a "random" object that we can test
+        body = self.make_request('GET', '/ga4gh/dos/v1/dataobjects')
+        data_object = body['data_objects'][9]
+        url = '/ga4gh/dos/v1/dataobjects/' + data_object['id']
+
+        # Try and update with no changes. The request is properly
+        # authenticated and should return HTTP 200.
+        params = {
+            'headers': {
+                'content-type': 'application/json',
+                'access_token': self.access_token
+            },
+            'body': {'data_object': data_object}
+        }
+        self.make_request('PUT', url, **params)
+
+        # Test adding an alias (acceptably unique to try
+        # retrieving the object by the alias)
+        data_object['aliases'].append(alias)
+
+        # Try and update, this time with a change.
+        params['body']['data_object'] = data_object
+        # This `expect_fail` thing feels kind of dirty, but it's more concise...
+        if expect_fail:
+            update_response = self.make_request('PUT', url, expected_status=400, **params)
+            return
+        update_response = self.make_request('PUT', url, **params)
+        self.assertEqual(data_object['id'], update_response['data_object_id'])
+
+        time.sleep(2)
+
+        # Test and see if the update took place by retrieving the object
+        # and checking its aliases
+        get_response = self.make_request('GET', url)
+        self.assertEqual(update_response['data_object_id'], get_response['data_object']['id'])
+        self.assertIn(alias, get_response['data_object']['aliases'])
+
+        # Testing the update again by using a DOS ListDataObjectsRequest
+        # to locate the object by its new alias.
+        list_request = {
+            'alias': alias,
+            # We know the alias is unique, so even though page_size > 1
+            # we expect only one result.
+            'page_size': 10
+        }
+        list_url = self.get_query_url('/ga4gh/dos/v1/dataobjects', list_request)
+        list_response = self.make_request('GET', list_url)
+        self.assertEqual(1, len(list_response['data_objects']))
+        self.assertIn(alias, list_response['data_objects'][0]['aliases'])
+
+        # Tear down and remove the test alias
+        params['body']['data_object']['aliases'].remove(alias)
+        self.make_request('PUT', url, **params)
+
+    def test_update_simple(self):
         """
         Demonstrates how updating a Data Object should work to
         include new fields. The lambda handles the conversion
         to the original document type.
         """
-        my_guid = 'doi:MY-IDENTIFIER'
-        # First get an object to update
+        self._test_alias('daltest:' + str(uuid.uuid1()))
 
-        data_object_id = "f4f437e8-dce2-4383-b99f-5d3da64e87a9"
-        url = '/ga4gh/dos/v1/dataobjects/{}'.format(data_object_id)
+    def test_update_ugly_alias(self):
+        """
+        Test with an 'ugly' alias to test alias key-value splitting
+        """
+        self._test_alias('daltest:abc:def:ghi' + str(uuid.uuid1()))
 
-        r, body = self.make_request('GET', '/ga4gh/dos/v1/dataobjects/' + data_object_id)
-        data_object = body['data_object']
-        # First we'll try to update something with no new
-        # information. Since it's an auth'ed endpoint, this
-        # should fail.
-
-        params = {
-            'headers': {
-                'content-type': 'applications/json'
-            },
-            'body': {
-                'data_object': data_object
-            },
-            'expected_status': 403
-        }
-        update_response = self.make_request('PUT', url, **params)
-
-        # Now we will set the headers for the remainder of
-        # the tests.
-
-        params['headers']['access_token'] = self.access_token
-        params['expected_status'] = 200
-        update_response = self.make_request('PUT', url, **params)
-
-        # Make sure it doesn't already include the GUID
-        self.assertNotIn(my_guid, data_object['aliases'])
-
-        # Next, we'll try to update with a "protected key", i.e.
-        # a value that has already been set on an item that is
-        # not in the list of safe keys.
-
-        data_object['aliases'].append('file_id:GARBAGEID')
-        params['body']['data_object'] = data_object
-        params['expected_status'] = 400
-        url = '/ga4gh/dos/v1/dataobjects/{}'.format(data_object['id'])
-        update_response = self.make_request('PUT', url, **params)
-
-        # Remove that "bad alias".
-        data_object['aliases'] = data_object['aliases'][:-1]
-
-        # Modify to include a GUID
-        data_object['aliases'].append(my_guid)
-
-        # Make an update request
-        params['body']['data_object'] = data_object
-        params['expected_status'] = 200
-        update_response = self.make_request('PUT', url, **params)
-        self.assertEqual(data_object['id'], update_response['data_object_id'])
-
-        import time
-        time.sleep(2)
-        # Now get it again to verify it is there
-        get_response = self.make_request('GET', url)
-        got_data_object = get_response['data_object']
-        self.assertEqual(update_response['data_object_id'], got_data_object['id'])
-        self.assertIn(my_guid, got_data_object['aliases'])
-
-        # MEAT AND POTATOES - now we actually use a DOS
-        # ListDataObjectsRequest to find our item by the identifier
-        # we provided.
-
-        list_request = {
-            'alias': my_guid,
-            'page_size': 10}
-        url = self.get_query_url('/ga4gh/dos/v1/dataobjects', list_request)
-        list_response = self.make_request('GET', url)
-        data_objects = list_response['data_objects']
-        self.assertEqual(1, len(data_objects))
-        listed_object = data_objects[0]
-        self.assertIn(my_guid, listed_object['aliases'])
-
-        # Lastly, modify the value so we can rerun tests on the
-        # same object, make it an ugly thing to test the alias
-        # key value splitting
-
-        ugly_alias = "doi:abc:def:ghi"
-        data_object['aliases'][-1] = ugly_alias
-        params['body']['data_object'] = data_object
-        update_response = self.make_request('PUT', url, **params)
-        print('UPDATED RESPONSE')
-        print(update_response)
-        self.assertEqual(
-            data_object['id'], update_response['data_object_id'])
-        time.sleep(2)
-
-        get_response = self.make_request('GET', url)
-        got_data_object = get_response['data_object']
-        print('GOT OBJECT')
-        print(got_data_object)
-        self.assertIn(ugly_alias, got_data_object['aliases'])
-        time.sleep(2)
-        # Now get it again to verify it is gone
-        self.make_request('GET', url, headers=params['headers'])
-        got_data_object = get_response['data_object']
-        self.assertEqual(update_response['data_object_id'], got_data_object['id'])
-        self.assertNotIn(my_guid, got_data_object['aliases'])
+    def test_update_protected_key(self):
+        """
+        Try to update a data object with a 'protected key', i.e. a value
+        that has already been set on an item that is not in the list of
+        safe keys.
+        """
+        self._test_alias('file_id:GARBAGEID', expect_fail=True)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -94,36 +94,31 @@ class TestApp(TestCase):
         self.assertEquals(data_object['id'], data_object_id)
 
     def test_paging(self):
-        """
-        Demonstrates basic paging features.
+        """Demonstrates basic paging features."""
+        # Make a request that will return more than one data object
+        params = {
+            'method': 'GET',
+            'path': '/ga4gh/dos/v1/dataobjects',
+            'headers': {},
+            'body': '',
+        }
+        r = self.lg.handle_request(**params)
+        res = json.loads(r['body'])
+        self.assertTrue(len(res['data_objects']) > 1)
 
-        :return:
-        """
-        body = {
-            'alias': 'specimenUUID:d842b267-a154-5192-988b-b9f9f0265840',
-            'page_size': 1}
-        list_response = self.lg.handle_request(
-            method='GET',
-            path=self.get_query_url('/ga4gh/dos/v1/dataobjects', body),
-            headers={}, body='')
-        response_body = json.loads(list_response['body'])
-        data_objects = response_body['data_objects']
+        # Now that we have a request that will return more than one data
+        # object, we can test and see if we can use paging to return only
+        # one object.
+        params['path'] += '?page_size=1'
+        r = self.lg.handle_request(**params)
+        res = json.loads(r['body'])
+        self.assertEqual(len(res['data_objects']), 1)
+        self.assertEqual(res['next_page_token'], '1')
 
-        self.assertEquals(len(data_objects), 1)
-        self.assertEquals(response_body['next_page_token'], '1')
-
-        body = {
-            'alias': 'specimenUUID:d842b267-a154-5192-988b-b9f9f0265840',
-            'page_size': 1,
-            'page_token': response_body['next_page_token']}
-        list_response = self.lg.handle_request(
-            method='GET',
-            path=self.get_query_url('/ga4gh/dos/v1/dataobjects', body),
-            headers={}, body='')
-        response_body = json.loads(list_response['body'])
-        data_objects = response_body['data_objects']
-
-        self.assertEquals(len(data_objects), 1)
+        # Test that page tokens work.
+        params['path'] += '&page_token=1'
+        r = self.lg.handle_request(**params)
+        self.assertEqual(len(res['data_objects']), 1)
 
     def test_update(self):
         """

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from unittest import TestCase
 import urllib
 
@@ -7,11 +8,47 @@ from chalice.local import LocalGateway
 
 from app import app
 
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
 
 class TestApp(TestCase):
     def setUp(self):
         self.lg = LocalGateway(app, Config())
         self.access_token = "f4ce9d3d23f4ac9dfdc3c825608dc660"
+
+    def make_request(self, meth, path, headers={}, body=None, expected_status=200):
+        """
+        Wrapper function around :meth:`chalice.local.LocalGateway.handle_request`.
+        Calls :meth:`handle_request` with reasonable defaults and checks to
+        make sure that the request returns the expected status code.
+
+        :param str meth: the HTTP method to use in the request (i.e. GET, PUT, etc.)
+        :param str path: path to make a request to, sans hostname a la :meth:`handle_request`
+        :param dict headers: headers to include with the request
+        :param dict body: data to be included in the request body (**not** serialized as JSON)
+        :param int expected_status: expected HTTP status code. If the status code
+                                    is not expected, an error will be raised.
+        :rtype: dict
+        :returns: the response body
+        """
+        # Log the request being made, make the request itself, then log the response.
+        logger.info("%s %s", meth, path)
+        logger.debug("%s %s headers=%s body=%s", meth, path, headers, body)
+        request = self.lg.handle_request(
+            method=meth,
+            path=path,
+            headers=headers,
+            body=json.dumps(body))
+        rv = request['statusCode']
+        logger.error("--> Request returned HTTP %d:\n%s", rv, request['body'])
+
+        # Check to make sure the return code is what we expect
+        msg = "{meth} {path} returned HTTP {rv}, expected HTTP {expected_status}"
+        self.assertEqual(rv, expected_status, msg=msg.format(**locals()))
+
+        # Return the deserialized request body
+        return json.loads(request['body'])
 
     def get_query_url(self, path, body={}, **kwargs):
         body.update(kwargs)
@@ -20,113 +57,66 @@ class TestApp(TestCase):
     def test_auth(self):
         """
         Tests the basic access_token authentication method.
-
-        :return:
         """
-        response = self.lg.handle_request(
-            method='GET',
-            path='/test_token',
-            headers={},
-            body='')
-        self.assertEquals(response['statusCode'], 200)
-        response_body = json.loads(response['body'])
-        self.assertFalse(response_body['authorized'])
+        # If we don't provide a valid access token, the query should fail.
+        r = self.make_request('GET', '/test_token')
+        self.assertFalse(r['authorized'])
 
-        response = self.lg.handle_request(
-            method='GET',
-            path='/test_token',
-            headers={'access_token': self.access_token},
-            body='')
-        self.assertEquals(response['statusCode'], 200)
-        response_body = json.loads(response['body'])
-        self.assertTrue(response_body['authorized'])
+        # If we provide a valid access token, the query should succeed.
+        headers = {'access_token': self.access_token}
+        r = self.make_request('GET', '/test_token', headers=headers)
+        self.assertTrue(r['authorized'])
 
     def test_get_root(self):
         """
         Tests to see we can access the ES instance.
-
-        :return:
         """
-        response = self.lg.handle_request(
-            method='GET',
-            path='/',
-            headers={},
-            body='')
-        self.assertEquals(response['statusCode'], 200)
-        body_keys = json.loads(response['body']).keys()
-        self.assertIn('version', body_keys)
+        r = self.make_request('GET', '/')
+        self.assertIn('version', r.keys())
 
     def test_list_data_objects(self):
         """
         Test the listing feature returns a response.
-
-        :return:
         """
         pagesize = 10
-        response = self.lg.handle_request(
-            method='GET',
-            path=self.get_query_url('/ga4gh/dos/v1/dataobjects', pagesize=10),
-            headers={}, body='')
-
-        self.assertEquals(response['statusCode'], 200)
-        response_body = json.loads(response['body'])
-        self.assertEquals(len(response_body['data_objects']), pagesize)
+        r = self.make_request('GET', '/ga4gh/dos/v1/dataobjects?page_size=' + str(pagesize))
+        self.assertEqual(len(r['data_objects']), pagesize)
 
     def test_get_data_object(self):
         """
         Lists Data Objects and then gets one by ID.
-        :return:
         """
-        list_response = self.lg.handle_request(
-            method='GET',
-            path='/ga4gh/dos/v1/dataobjects',
-            headers={}, body='')
-
-        data_objects = json.loads(list_response['body'])['data_objects']
-        data_object_id = data_objects[0]['id']
-        response = self.lg.handle_request(
-            method='GET',
-            path='/ga4gh/dos/v1/dataobjects/{}'.format(data_object_id),
-            headers={},
-            body='')
-        self.assertEquals(response['statusCode'], 200)
-        data_object = json.loads(response['body'])['data_object']
-        self.assertEquals(data_object['id'], data_object_id)
+        # List all the data objects so we can pick one to test.
+        r = self.make_request('GET', '/ga4gh/dos/v1/dataobjects')
+        data_object_1 = r['data_objects'][0]
+        r = self.make_request('GET', '/ga4gh/dos/v1/dataobjects/' + data_object_1['id'])
+        data_object_2 = r['data_object']
+        self.assertEqual(data_object_1, data_object_2)
 
     def test_paging(self):
-        """Demonstrates basic paging features."""
+        """
+        Demonstrates basic paging features.
+        """
         # Make a request that will return more than one data object
-        params = {
-            'method': 'GET',
-            'path': '/ga4gh/dos/v1/dataobjects',
-            'headers': {},
-            'body': '',
-        }
-        r = self.lg.handle_request(**params)
-        res = json.loads(r['body'])
-        self.assertTrue(len(res['data_objects']) > 1)
+        r = self.make_request('GET', '/ga4gh/dos/v1/dataobjects')
+        self.assertTrue(len(r['data_objects']) > 1)
 
-        # Now that we have a request that will return more than one data
-        # object, we can test and see if we can use paging to return only
-        # one object.
-        params['path'] += '?page_size=1'
-        r = self.lg.handle_request(**params)
-        res = json.loads(r['body'])
-        self.assertEqual(len(res['data_objects']), 1)
-        self.assertEqual(res['next_page_token'], '1')
+        # Now that we have a request that we know will return more than
+        # one data object, we can test and see if we can use paging to
+        # return only one of those objects.
+        r = self.make_request('GET', '/ga4gh/dos/v1/dataobjects?page_size=1')
+        self.assertEqual(len(r['data_objects']), 1)
+        self.assertEqual(r['next_page_token'], '1')
 
         # Test that page tokens work.
-        params['path'] += '&page_token=1'
-        r = self.lg.handle_request(**params)
-        self.assertEqual(len(res['data_objects']), 1)
+        r = self.make_request('GET', '/ga4gh/dos/v1/dataobjects?page_size=1&page_token=1')
+        self.assertEqual(len(r['data_objects']), 1)
 
     def test_update(self):
         """
         Demonstrates how updating a Data Object should work to
         include new fields. The lambda handles the conversion
         to the original document type.
-
-        :return:
         """
         my_guid = 'doi:MY-IDENTIFIER'
         # First get an object to update
@@ -134,38 +124,29 @@ class TestApp(TestCase):
         data_object_id = "f4f437e8-dce2-4383-b99f-5d3da64e87a9"
         url = '/ga4gh/dos/v1/dataobjects/{}'.format(data_object_id)
 
-        get_response = self.lg.handle_request(
-            method='GET',
-            path=url,
-            headers={},
-            body='')
-        self.assertEquals(get_response['statusCode'], 200)
-        data_object = json.loads(get_response['body'])['data_object']
-        update_request = {'data_object': data_object}
+        r, body = self.make_request('GET', '/ga4gh/dos/v1/dataobjects/' + data_object_id)
+        data_object = body['data_object']
         # First we'll try to update something with no new
         # information. Since it's an auth'ed endpoint, this
         # should fail.
 
-        update_response = self.lg.handle_request(
-            method='PUT',
-            path=url,
-            headers={'content-type': 'application/json'},
-            body=json.dumps(update_request))
-        self.assertEquals(update_response['statusCode'], 403)
+        params = {
+            'headers': {
+                'content-type': 'applications/json'
+            },
+            'body': {
+                'data_object': data_object
+            },
+            'expected_status': 403
+        }
+        update_response = self.make_request('PUT', url, **params)
 
         # Now we will set the headers for the remainder of
         # the tests.
 
-        headers = {
-            'content-type': 'application/json',
-            'access_token': self.access_token}
-
-        update_response = self.lg.handle_request(
-            method='PUT',
-            path=url,
-            headers=headers,
-            body=json.dumps(update_request))
-        self.assertEquals(update_response['statusCode'], 200)
+        params['headers']['access_token'] = self.access_token
+        params['expected_status'] = 200
+        update_response = self.make_request('PUT', url, **params)
 
         # Make sure it doesn't already include the GUID
         self.assertNotIn(my_guid, data_object['aliases'])
@@ -175,14 +156,10 @@ class TestApp(TestCase):
         # not in the list of safe keys.
 
         data_object['aliases'].append('file_id:GARBAGEID')
-        update_request = {'data_object': data_object}
+        params['body']['data_object'] = data_object
+        params['expected_status'] = 400
         url = '/ga4gh/dos/v1/dataobjects/{}'.format(data_object['id'])
-        update_response = self.lg.handle_request(
-            method='PUT',
-            path=url,
-            headers=headers,
-            body=json.dumps(data_object))
-        self.assertEquals(update_response['statusCode'], 400)
+        update_response = self.make_request('PUT', url, **params)
 
         # Remove that "bad alias".
         data_object['aliases'] = data_object['aliases'][:-1]
@@ -191,48 +168,30 @@ class TestApp(TestCase):
         data_object['aliases'].append(my_guid)
 
         # Make an update request
-        update_request = {'data_object': data_object}
-        update_response = self.lg.handle_request(
-            method='PUT',
-            path=url,
-            headers=headers,
-            body=json.dumps(update_request))
-        self.assertEquals(update_response['statusCode'], 200)
-        update_response_body = json.loads(update_response['body'])
-        self.assertEqual(
-            data_object['id'], update_response_body['data_object_id'])
+        params['body']['data_object'] = data_object
+        params['expected_status'] = 200
+        update_response = self.make_request('PUT', url, **params)
+        self.assertEqual(data_object['id'], update_response['data_object_id'])
 
         import time
         time.sleep(2)
         # Now get it again to verify it is there
-        get_response = self.lg.handle_request(
-            method='GET',
-            path=url,
-            headers={},
-            body='')
-        self.assertEquals(get_response['statusCode'], 200)
-        get_response_body = json.loads(get_response['body'])
-        got_data_object = get_response_body['data_object']
-        self.assertEqual(
-            update_response_body['data_object_id'],
-            got_data_object['id'])
-
+        get_response = self.make_request('GET', url)
+        got_data_object = get_response['data_object']
+        self.assertEqual(update_response['data_object_id'], got_data_object['id'])
         self.assertIn(my_guid, got_data_object['aliases'])
 
         # MEAT AND POTATOES - now we actually use a DOS
-        # ListDataObjectsRequest to find our item by the
-        # identifier we provided.
+        # ListDataObjectsRequest to find our item by the identifier
+        # we provided.
 
         list_request = {
             'alias': my_guid,
             'page_size': 10}
-        list_response = self.lg.handle_request(
-            method='GET',
-            path=self.get_query_url('/ga4gh/dos/v1/dataobjects', list_request),
-            headers={}, body='')
-        response_body = json.loads(list_response['body'])
-        data_objects = response_body['data_objects']
-        self.assertEquals(1, len(data_objects))
+        url = self.get_query_url('/ga4gh/dos/v1/dataobjects', list_request)
+        list_response = self.make_request('GET', url)
+        data_objects = list_response['data_objects']
+        self.assertEqual(1, len(data_objects))
         listed_object = data_objects[0]
         self.assertIn(my_guid, listed_object['aliases'])
 
@@ -242,42 +201,22 @@ class TestApp(TestCase):
 
         ugly_alias = "doi:abc:def:ghi"
         data_object['aliases'][-1] = ugly_alias
-        update_request = {'data_object': data_object}
-        update_response = self.lg.handle_request(
-            method='PUT',
-            path=url,
-            headers=headers,
-            body=json.dumps(update_request))
-        self.assertEquals(update_response['statusCode'], 200)
-        update_response_body = json.loads(update_response['body'])
+        params['body']['data_object'] = data_object
+        update_response = self.make_request('PUT', url, **params)
         print('UPDATED RESPONSE')
-        print(update_response_body)
+        print(update_response)
         self.assertEqual(
-            data_object['id'], update_response_body['data_object_id'])
+            data_object['id'], update_response['data_object_id'])
         time.sleep(2)
 
-        get_response = self.lg.handle_request(
-            method='GET',
-            path=url,
-            headers={},
-            body='')
-        self.assertEquals(get_response['statusCode'], 200)
-        get_response_body = json.loads(get_response['body'])
-        got_data_object = get_response_body['data_object']
+        get_response = self.make_request('GET', url)
+        got_data_object = get_response['data_object']
         print('GOT OBJECT')
         print(got_data_object)
         self.assertIn(ugly_alias, got_data_object['aliases'])
         time.sleep(2)
         # Now get it again to verify it is gone
-        get_response = self.lg.handle_request(
-            method='GET',
-            path=url,
-            headers=headers,
-            body='')
-        self.assertEquals(get_response['statusCode'], 200)
-        get_response_body = json.loads(get_response['body'])
-        got_data_object = get_response_body['data_object']
-        self.assertEqual(
-            update_response_body['data_object_id'],
-            got_data_object['id'])
+        self.make_request('GET', url, headers=params['headers'])
+        got_data_object = get_response['data_object']
+        self.assertEqual(update_response['data_object_id'], got_data_object['id'])
         self.assertNotIn(my_guid, got_data_object['aliases'])


### PR DESCRIPTION
This is a large-ish PR.

* Tests have been refactored to improve readability
* Tests using hardcoded IDs to identify objects to test have also been fixed to "randomly" select an object to test
* Fixed an issue where attempting to retrieve data objects by their alias would produce unexpected results
* Fixed a bug where a `ListDataObjects` parameter was not cast correctly

I generally try to keep my PRs well-defined and well-scoped, but most of the things I felt needed to be fixed revealed themselves in the course of closing this ticket and were necessary to complete it.

Travis tests will still fail because the PEP8 linter is still checking for E501 (line length). I will disable this check in #31.
