### PR TITLE
Add Python 3 compatibility (closes #58)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
 - '2.7'
+- '3.6'
 branches:
   only:
   - master

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ For more information refer to the [Data Object Service](https://github.com/ga4gh
 
 ### Status
 
+dos-azul-lambda is tested against Python 2.7 and Python 3.6.
+
 This software is being actively developed to provide basic access to listing of
 Data Objects made available by the dss-azul-indexer.
 

--- a/app.py
+++ b/app.py
@@ -242,15 +242,9 @@ def list_data_objects(**kwargs):
                                    from_=page_token if page_token != 0 else None)
     else:
         results = es_query(query={}, index=INDEXES['data_obj'], size=per_page + 1)
-
+    response = {'data_objects': [azul_to_obj(x) for x in results[:per_page]]}
     if len(results) > per_page:
-        next_page_token = str(int(page_token) + 1)
-    else:
-        next_page_token = None
-    data_objects = map(azul_to_obj, results)
-    response = {'data_objects': data_objects[0:per_page]}
-    if next_page_token:
-        response['next_page_token'] = next_page_token
+        response['next_page_token'] = str(int(page_token) + 1)
     return response
 
 
@@ -271,15 +265,9 @@ def list_data_bundles(**kwargs):
                                    from_=page_token if page_token != 0 else None)
     else:
         results = es_query(query={}, index=INDEXES['data_bdl'], size=per_page + 1)
-
+    response = {'data_bundles': [azul_to_bdl(x) for x in results[:per_page]]}
     if len(results) > per_page:
-        next_page_token = str(int(page_token) + 1)
-    else:
-        next_page_token = None
-    data_objects = map(azul_to_bdl, results)
-    response = {'data_bundles': data_objects[0:per_page]}
-    if next_page_token:
-        response['next_page_token'] = next_page_token
+        response['next_page_token'] = str(int(page_token) + 1)
     return response
 
 
@@ -322,14 +310,7 @@ def update_data_object(data_object_id):
         return Response({'msg': 'Please add a data_object to the body of your request'},
                         status_code=400)
 
-    new_aliases = filter(
-        lambda x: x not in data_object['aliases'],
-        update_data_object['aliases'])
-    # if len(new_aliases) == 0:
-    #     return Response(
-    #         {'msg': 'No new aliases, nothing was changed. '
-    #                 'Please check your request details.'}, status_code=400)
-
+    new_aliases = [x for x in update_data_object['aliases'] if x not in data_object['aliases']]
     data_object['aliases'] = data_object['aliases'] + new_aliases
 
     es_id = source['_id']

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,8 +1,7 @@
 import json
 import logging
 import time
-from unittest import TestCase
-import urllib
+import unittest
 import uuid
 
 from chalice.config import Config
@@ -10,11 +9,16 @@ from chalice.local import LocalGateway
 
 from app import app, access_token
 
+try:
+    import urllib.parse as urllib  # For Python 3 compat
+except ImportError:
+    import urllib
+
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-class TestApp(TestCase):
+class TestApp(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.lg = LocalGateway(app, Config())
@@ -75,7 +79,7 @@ class TestApp(TestCase):
         Tests to see we can access the ES instance.
         """
         r = self.make_request('GET', '/')
-        self.assertIn('version', r.keys())
+        self.assertIn('version', list(r.keys()))
 
     def test_list_data_objects(self):
         """


### PR DESCRIPTION
This PR adds support for Python 3.6. Support for Python 2.7 is maintained. Travis will now also build against 3.6 in addition to 2.7.