### PR TITLE
Improve test isolation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
 - '2.7'
-env:
-- ES_HOST="search-dos-azul-test-a998691e-uuzze4esxbslgnc4i3pnbzjpq4.us-west-2.es.amazonaws.com" TEST_ES_DOMAIN="dos-azul-test-a998691e"
 branches:
   only:
   - master
@@ -10,11 +8,20 @@ before_install:
 - sudo apt-get update -qq
 - pip install -r dev-requirements.txt
 - pip install -r requirements.txt
+# We set these environment variables here instead of in `env` as
+# provision/provision.py requires boto3
+- export TEST_ES_DOMAIN=$(python provision/provision.py setup)
+- echo ${TEST_ES_DOMAIN}
+# Strip the leading `http://`
+- export ES_HOST=$(python provision/provision.py get-endpoint ${TEST_ES_DOMAIN})
+- export ES_HOST=$(echo ${ES_HOST} | sed 's~http[s]*://~~g')
+- echo ${ES_HOST}
 before_script:
-- python provision/provision.py raze ${TEST_ES_DOMAIN}
 - python provision/provision.py populate ${TEST_ES_DOMAIN}
+# Wait a few seconds to let ES catch up
+- sleep 3
 script:
 - flake8 --select=E121,E123,E126,E226,E24,E704,W503,W504 --ignore=E501 app.py tests
 - nosetests
 after_script:
-- python provision/provision.py raze ${TEST_ES_DOMAIN}
+- python provision/provision.py teardown ${TEST_ES_DOMAIN}

--- a/provision/provision.py
+++ b/provision/provision.py
@@ -133,7 +133,7 @@ if __name__ == '__main__':
     if command == 'teardown':
         teardown(sys.argv[2])
     elif command == 'setup':
-        if sys.argv < 3:
+        if len(sys.argv) > 3:
             domain = sys.argv[3]
         else:
             domain = None


### PR DESCRIPTION
This PR spins up a new ES domain for each test run, switching from the shared-resource model. This will drastically increase the amount of time it takes for tests to run (+10 min or so) but I think it's the best option because we can no longer reuse a single ES instance for testing if we're going to test against both 2.6 and 3.7 concurrently (ref #69).

This also seems to be the best option over these alternatives:
* LocalStack (won't work because it doesn't play nice with boto)
* Using `dss-azul-commons` (won't work because we need clean test data)
* A local ES Docker container (not preferable because AWS presents a different API than ES, plus getting it to work with boto would be non-trivial?)

On the plus side, we get the following benefits:
* No ES instance running 24/7 will save some amount of money
* PRs being tested at the same time will no longer clobber each other