### PR TITLE
Update Chalice requirement to 1.6.0 (closes #20)

### DIFF
--- a/.chalice/config.json
+++ b/.chalice/config.json
@@ -26,7 +26,6 @@
   "app_name": "dos-azul-lambda",
   "environment_variables": {
     "DATA_OBJ_INDEX": "fb_index",
-    "HOME": "/tmp",
     "DEBUG": "False"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-chalice==1.2.2
+chalice>=1.6.0,<2
 requests
 PyYAML
 boto


### PR DESCRIPTION
This commit also fixes an issue where deployments would
fail with a Chalice version over 1.2.3.

See [this comment](https://github.com/databiosphere/dos-azul-lambda/issues/20#issuecomment-412162198) for an explanation of the bug