### PR TITLE
Implement continuous deployment (closes #30)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,20 @@ script:
 - nosetests
 after_script:
 - python provision/provision.py teardown ${TEST_ES_DOMAIN}
+# We want to deploy dos-azul-lambda to `dev` on every commit to master
+# that builds successfully and to `staging` on every tagged commit to
+# master that builds successfully.
+deploy:
+- provider: script
+  script: chalice deploy --stage dev --no-autogen-policy
+  on:
+    repo: DataBiosphere/dos-azul-lambda
+    branch: master
+    python: '3.6'
+- provider: script
+  script: chalice deploy --stage staging --no-autogen-policy
+  on:
+    repo: DataBiosphere/dos-azul-lambda
+    branch: master
+    python: '3.6'
+    tags: true


### PR DESCRIPTION
This pull request implements continuous deployment using Chalice through Travis with the following behavior:
* `dos-azul-lambda` will be deployed to `dev` if any commit is made to master that builds successfully
* `dos-azul-lambda` will be deployed to `staging` if any commit is made to master that builds successfully and is tagged

So a tagged commit that passes tests would be deployed to both `dev` and `staging`.
Builds triggered by pull requests automatically skip the deployment step regardless of whether criteria are met, so you won't see the results of the deploy in this commit.