### PR TITLE
Provisioner improvements

### DIFF
--- a/provision/policy.json
+++ b/provision/policy.json
@@ -10,7 +10,7 @@
         ]
       },
       "Action": "es:*",
-      "Resource": "arn:aws:es:us-west-2:${aws_id}:domain/${es_domain}/*"
+      "Resource": "arn:aws:es:${region}:${aws_id}:domain/${es_domain}/*"
     }
   ]
 }

--- a/provision/policy.json
+++ b/provision/policy.json
@@ -4,25 +4,12 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::${aws_id}:root"
+        "AWS": [
+            "arn:aws:iam::${aws_id}:root",
+            "${user_arn}"
+        ]
       },
       "Action": "es:*",
-      "Resource": "arn:aws:es:us-west-2:${aws_id}:domain/${es_domain}/*"
-    },
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "${user_arn}"
-      },
-      "Action": "es:*",
-      "Resource": "arn:aws:es:us-west-2:${aws_id}:domain/${es_domain}/*"
-    },
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "arn:aws:iam::${aws_id}:user/travis_integration_test_CGP"
-      },
-      "Action": "es:ESHttp*",
       "Resource": "arn:aws:es:us-west-2:${aws_id}:domain/${es_domain}/*"
     }
   ]

--- a/provision/provision.py
+++ b/provision/provision.py
@@ -106,8 +106,8 @@ def setup(es_domain=None):
     if not es_domain:
         es_domain = 'dos-azul-test-' + str(uuid.uuid1()).split('-')[0]
     aws_info = boto3.client('sts').get_caller_identity()
-    # The access policy has curly braces so we can't use str.format()
-    # https://github.com/DataBiosphere/azul/blob/feature/commons/indexer/policies/elasticsearch-policy.json
+
+    # Generate the polic from policy.json, filling in the blanks.
     with open(getpath('policy.json'), 'r') as ES_ACCESS_POLICY:
         policy = string.Template(ES_ACCESS_POLICY.read()).substitute({
             'aws_id': aws_info['Account'],

--- a/provision/provision.py
+++ b/provision/provision.py
@@ -106,13 +106,15 @@ def setup(es_domain=None):
     if not es_domain:
         es_domain = 'dos-azul-test-' + str(uuid.uuid1()).split('-')[0]
     aws_info = boto3.client('sts').get_caller_identity()
+    region = boto3.session.Session().region_name
 
-    # Generate the polic from policy.json, filling in the blanks.
+    # Generate the policy from policy.json, filling in the blanks.
     with open(getpath('policy.json'), 'r') as ES_ACCESS_POLICY:
         policy = string.Template(ES_ACCESS_POLICY.read()).substitute({
             'aws_id': aws_info['Account'],
             'es_domain': es_domain,
-            'user_arn': aws_info['Arn']
+            'user_arn': aws_info['Arn'],
+            'region': region
         })
     es.create_elasticsearch_domain(
         DomainName=es_domain,


### PR DESCRIPTION
We can remove Travis's hardcoded access in `policy.json` because it is automatically assigned access when the scripts are run. I mistakenly believed that this would not be the case. 