### PR TITLE
Do not run if ES_HOST unspecified (closes #102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ dos-azul-lambda can be configured by setting a number of environment variables:
 * Set `ES_HOST` to specify the hostname of the ElasticSearch instance. **This
   must be manually set.** The endpoint should be specified without a leading
   protocol (e.g. `search-es-instance-12345.us-west-2.es.amazonaws.com`).
-  For the `dev` stage deployment of dos-azul-lambda, `ES_HOST` points to
+  By default, on live deployments of dos-azul-lambda, `ES_HOST` points to
   `dss-azul-commons` (when deployed via `chalice` - see `.chalice/config.json`).
   (Note that you shouldn't run tests against `dss-azul-commons` as is - see #102.)
 * Set `ES_REGION` to override the default AWS region of the ElasticSearch

--- a/README.md
+++ b/README.md
@@ -225,12 +225,12 @@ dos-azul-lambda can be configured by setting a number of environment variables:
 * Set `DATA_BDL_DOCTYPE` to override the name of the ElasticSearch document type
   that dos-azul-lambda should expect to correspond with `DATA_BDL_INDEX`. By
   default, this is `databundle`.
-* Set `ES_HOST` to override the hostname of the ElasticSearch instance. On dev,
-  this points to the `dss-azul-commons` ElasticSearch instance
-  (`search-dss-azul-commons-lx3ltgewjw5wiw2yrxftoqr7jy.us-west-2.es.amazonaws.com`).
-  This variable should be specified without the protocol (i.e. without a leading
-  `http://` or `https://`). dos-azul-lambda will not run unless this variable is
-  specified.
+* Set `ES_HOST` to specify the hostname of the ElasticSearch instance. **This
+  must be manually set.** The endpoint should be specified without a leading
+  protocol (e.g. `search-es-instance-12345.us-west-2.es.amazonaws.com`).
+  For the `dev` stage deployment of dos-azul-lambda, `ES_HOST` points to
+  `dss-azul-commons` (when deployed via `chalice` - see `.chalice/config.json`).
+  (Note that you shouldn't run tests against `dss-azul-commons` as is - see #102.)
 * Set `ES_REGION` to override the default AWS region of the ElasticSearch
   instance. By default, this is `us-west-2`.
 * Set `ACCESS_KEY` to override the default access token used to authenticate to

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Here is an example config.json
 Note the environment variables, which are passed to the application. The `ACCESS_KEY`
 should be a hard to guess string of letters and numbers. When requests to modify
 an index are made, this value is checked for in the `access_key` header of the request.
+Also note `ES_HOST` - this is the only mandatory variable. Without it, the lambda will
+not run.
 
 Then, create a file `.chalice/policy-dev.json` so it can access you azul index, assuming its
 permissions have been set to allow it.
@@ -223,10 +225,12 @@ dos-azul-lambda can be configured by setting a number of environment variables:
 * Set `DATA_BDL_DOCTYPE` to override the name of the ElasticSearch document type
   that dos-azul-lambda should expect to correspond with `DATA_BDL_INDEX`. By
   default, this is `databundle`.
-* Set `ES_HOST` to override the hostname of the ElasticSearch instance. By
-  default, this points to the `dss-azul-commons` ElasticSearch instance. This
-  variable should be specified without the protocol (i.e. without a leading
-  `http://` or `https://`).
+* Set `ES_HOST` to override the hostname of the ElasticSearch instance. On dev,
+  this points to the `dss-azul-commons` ElasticSearch instance
+  (`search-dss-azul-commons-lx3ltgewjw5wiw2yrxftoqr7jy.us-west-2.es.amazonaws.com`).
+  This variable should be specified without the protocol (i.e. without a leading
+  `http://` or `https://`). dos-azul-lambda will not run unless this variable is
+  specified.
 * Set `ES_REGION` to override the default AWS region of the ElasticSearch
   instance. By default, this is `us-west-2`.
 * Set `ACCESS_KEY` to override the default access token used to authenticate to

--- a/app.py
+++ b/app.py
@@ -117,10 +117,6 @@ class ESConnection(AWSAuthConnection):
         return ['hmac-v4']
 
 
-# Ensure that you set 'host' below to the FQDN for YOUR
-# Elasticsearch service endpoint
-
-DEFAULT_HOST = 'search-dss-azul-commons-lx3ltgewjw5wiw2yrxftoqr7jy.us-west-2.es.amazonaws.com'
 DEFAULT_REGION = 'us-west-2'
 DEFAULT_ACCESS_TOKEN = 'f4ce9d3d23f4ac9dfdc3c825608dc660'
 
@@ -134,7 +130,11 @@ DOCTYPES = {
     'data_bdl': os.environ.get('DATA_BDL_DOCTYPE', 'databundle'),
 }
 
-es_host = os.environ.get('ES_HOST', DEFAULT_HOST)
+try:
+    es_host = os.environ['ES_HOST']
+except KeyError:
+    raise RuntimeError("You must specify the domain name of your ElasticSearch"
+                       " instance with the ES_HOST environment variable.")
 es_region = os.environ.get('ES_REGION', DEFAULT_REGION)
 access_token = os.environ.get('ACCESS_KEY', DEFAULT_ACCESS_TOKEN)
 client = ESConnection(region=es_region, host=es_host, is_secure=False)


### PR DESCRIPTION
Also closes TLP-542.
This PR stops dos-azul-lambda from assuming a default ES_HOST if none is
provided and updates the README to that effect. ES_HOST has already been
specified for all stages in .chalice/config.json, so no changes to those
deployments should be required.

This change will prevent users from inadvertently contaminating
dss-azul-commons should tests fail.