### PR TITLE
Switch testing instance to t2.small

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ install:
 
 before_script:
   - python provision/provision.py populate ${TEST_ES_DOMAIN}
-  - sleep 3  # Wait a few seconds to let ES catch up
+  - sleep 10  # Wait for ES to catch up
 
 script:
   - nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ python:
 # to start a new ElasticSearch instance.
 env:
   global:
-    - ES_HOST="search-dos-azul-test-7f6ecc04-xfo4lbmxzvafkrw5pbslkggpye.us-west-2.es.amazonaws.com"
+    - ES_HOST="search-dos-azul-test-f612cc56-upv6ilywi26bm2jb3xxgszqq7q.us-west-2.es.amazonaws.com"
     - DATA_OBJ_INDEX="dataobj_${RANDOM}"
     - DATA_BDL_INDEX="databdl_${RANDOM}"
-    - TEST_ES_DOMAIN="dos-azul-test-7f6ecc04"
+    - TEST_ES_DOMAIN="dos-azul-test-f612cc56"
 
 # Specifying `branches.only = ['master']` can cause tagged builds to
 # not deploy. See travis-ci/travis-ci#2498 and travis-ci/travis-ci#1675.

--- a/provision/provision.py
+++ b/provision/provision.py
@@ -126,10 +126,15 @@ def setup(es_domain=None):
         DomainName=es_domain,
         ElasticsearchVersion='5.5',
         ElasticsearchClusterConfig={
-            'InstanceType': 'i3.large.elasticsearch',
+            'InstanceType': 't2.small.elasticsearch',
             'InstanceCount': 1,
             'DedicatedMasterEnabled': False,
             'ZoneAwarenessEnabled': False,
+        },
+        EBSOptions={  # required for t2.small.elasticsearch
+            'EBSEnabled': True,
+            'VolumeType': 'standard',  # st1 is cheaper but not supported
+            'VolumeSize': 10,  # minimum for t2.small.elasticsearch
         },
         AccessPolicies=policy,
         CognitoOptions={'Enabled': False},


### PR DESCRIPTION
This will cut the cost of running the testing domain by about 90%
with negligible performance impact (since traffic is infrequent)