### PR TITLE
Replace boto with boto3 (closes #73)

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,2 @@
 flake8
 nose
-boto3==1.7.59

--- a/provision/provision.py
+++ b/provision/provision.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """
 $ provision/provision.py {setup,teardown,populate,raze} <domain>
+
+Domain is in the format short-name-here and NOT https://search-short-name-here-...
 """
 import json
 import logging
@@ -8,13 +10,12 @@ import os
 import string
 import sys
 import time
-import uuid
 
 import boto3
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-es = boto3.client('es')
+aws = boto3.client('es')
 
 # Get index names
 obj_index = os.environ.get('DATA_OBJ_INDEX', 'fb_index')
@@ -23,13 +24,6 @@ bdl_index = os.environ.get('DATA_BDL_INDEX', 'db_index')
 
 def getpath(filename):
     return os.path.abspath(os.path.join(os.path.dirname(__file__), filename))
-
-
-def get_request_handler(endpoint):
-    sys.path.insert(0, getpath('..'))
-    os.environ['ES_HOST'] = endpoint[7:]  # remove http://
-    from app import make_es_request
-    return make_es_request
 
 
 def get_endpoint(es_domain):
@@ -42,7 +36,7 @@ def get_endpoint(es_domain):
     backoff = 0
     status = {}
     while not status.get('DomainStatus', {}).get('Endpoint', None):
-        status = es.describe_elasticsearch_domain(DomainName=es_domain)
+        status = aws.describe_elasticsearch_domain(DomainName=es_domain)
         # \sum_{n=0}^{9} 2^n is a long time and if there hasn't been a response
         # by then, one probably isn't coming anytime soon.
         if backoff > 10:
@@ -56,7 +50,7 @@ def get_endpoint(es_domain):
 
     # boto3 returns the endpoint without the URL protocol, so we need
     # to add it if it doesn't exist, otherwise requests will choke
-    return 'http://' + status['DomainStatus']['Endpoint']
+    return 'https://' + status['DomainStatus']['Endpoint']
 
 
 def populate_domain(endpoint):
@@ -64,19 +58,11 @@ def populate_domain(endpoint):
     Given an ElasticSearch endpoint, populates the domain with a
     'faithful' replica of dss-azul-commons for testing purposes.
     """
-    # boto3 can't sign requests by default, so we pull the boto2 request
-    # handler from app.py (which is already nicely configured)
-    make_es_request = get_request_handler(endpoint)
-
-    # Set up fb_index (data_objects)
+    # Set up indexes
     with open(getpath('index-mapping.json'), 'r') as data:
-        payload = json.load(data)['fb_index']
-    make_es_request(method='PUT', path='/' + obj_index, data=json.dumps(payload))
-
-    # Set up db_index (data bundles)
-    with open(getpath('index-mapping.json'), 'r') as data:
-        payload = json.load(data)['db_index']
-    make_es_request(method='PUT', path='/' + bdl_index, data=json.dumps(payload))
+        index_cfg = json.load(data)
+    es.indices.create(index=obj_index, body=json.dumps(index_cfg['fb_index']))
+    es.indices.create(index=bdl_index, body=json.dumps(index_cfg['db_index']))
 
     # Populate both indexes
     with open(getpath('test-data.json'), 'r') as data:
@@ -86,7 +72,7 @@ def populate_domain(endpoint):
             'data_obj': obj_index,
             'data_bdl': bdl_index
         })
-        make_es_request(method='POST', path='/_bulk', data=payload)
+        es.bulk(body=payload)
 
 
 def raze_domain(endpoint):
@@ -94,23 +80,15 @@ def raze_domain(endpoint):
     Given an ElasticSearch endpoint, drops fb_index and db_index so that
     it can be populated anew.
     """
-    # boto3 can't sign requests by default, so we pull the boto2 request
-    # handler from app.py (which is already nicely configured)
-    make_es_request = get_request_handler(endpoint)
-
-    # Drop fb_index
-    make_es_request(method='DELETE', path='/' + obj_index)
-
-    # Drop db_index
-    make_es_request(method='DELETE', path='/' + bdl_index)
+    # Drop indexes
+    es.indices.delete(index=obj_index)
+    es.indices.delete(index=bdl_index)
 
 
-def setup(es_domain=None):
+def setup(es_domain):
     """
     Sets up an ElasticSearch domain.
     """
-    if not es_domain:
-        es_domain = 'dos-azul-test-' + str(uuid.uuid1()).split('-')[0]
     aws_info = boto3.client('sts').get_caller_identity()
     region = boto3.session.Session().region_name
 
@@ -122,7 +100,7 @@ def setup(es_domain=None):
             'user_arn': aws_info['Arn'],
             'region': region
         })
-    es.create_elasticsearch_domain(
+    aws.create_elasticsearch_domain(
         DomainName=es_domain,
         ElasticsearchVersion='5.5',
         ElasticsearchClusterConfig={
@@ -144,21 +122,17 @@ def setup(es_domain=None):
 
 
 def teardown(es_domain):
-    es.delete_elasticsearch_domain(DomainName=es_domain)
+    aws.delete_elasticsearch_domain(DomainName=es_domain)
 
 
 if __name__ == '__main__':
-    command = sys.argv[1]
-    if command == 'teardown':
-        teardown(sys.argv[2])
-    elif command == 'setup':
-        if len(sys.argv) > 3:
-            domain = sys.argv[3]
-        else:
-            domain = None
+    _, command, domain = sys.argv
+    # All commands require an endpoint except for `setup`, so check for
+    # that first. (`setup` still requires a domain to name the ElasticSearch
+    # instance that will be created.)
+    if command == 'setup':
         # Create a new domain
         es_domain = setup(es_domain=domain)
-
         # We need to wait for the instance to spin up before we can do anything
         # with it. This is the long part - Amazon says it takes about ten minutes.
         logger.info("Waiting for the ElasticSearch domain to become available.")
@@ -166,11 +140,25 @@ if __name__ == '__main__':
         time.sleep(60 * 7)
         get_endpoint(es_domain)
         sys.stdout.write(es_domain)
+        exit(0)
+    # We check to make sure that the command exists before importing the
+    # ElasticSearch client in case no domain has been provided
+    elif command not in ['teardown', 'populate', 'raze', 'get-endpoint']:
+        print(__doc__)
+        raise RuntimeError("Unknown command")
+
+    # If we are here, an endpoint should exist, so we can set up the
+    # ElasticSearch client
+    endpoint = get_endpoint(domain)
+    sys.path.insert(0, getpath('..'))
+    os.environ['ES_HOST'] = endpoint.replace('http://', '').replace('https://', '')
+    from app import es
+
+    if command == 'teardown':
+        teardown(domain)
     elif command == 'populate':
         populate_domain(get_endpoint(sys.argv[2]))
     elif command == 'raze':
         raze_domain(get_endpoint(sys.argv[2]))
     elif command == 'get-endpoint':
         sys.stdout.write(get_endpoint(sys.argv[2]))
-    else:
-        raise RuntimeError("Unknown command")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
+aws-requests-auth==0.4.2
+boto3==1.7.59
 chalice>=1.6.0,<2
-boto
-botocore
+# Updates to the elasticsearch dependency should fall within elasticsearch>=5.0.0,<6.0.0
+elasticsearch==5.5.3
 ga4gh-dos-schemas==0.4.2
-#bravado
-# implicit requirement from boto that travis complains about
-google_compute_engine


### PR DESCRIPTION
This commit updates app.py and specified dependencies to use
boto3 over boto, which allows us to improve our Python 3.x support.
In the process of doing so, "manual" calls to ElasticSearch have
been replaced with the ElasticSearch Python bindings, which provide
more robust logging and error handling.

The provisioning script is also updated to use boto3 and the
ElasticSearch bindings.